### PR TITLE
FDA Client Service Implementation

### DIFF
--- a/src/main/java/com/emerald/fda/records/api/config/RestTemplateConfig.java
+++ b/src/main/java/com/emerald/fda/records/api/config/RestTemplateConfig.java
@@ -1,0 +1,18 @@
+package com.emerald.fda.records.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    /**
+     * Creates and configures a RestTemplate bean.
+     *
+     * @return the configured RestTemplate instance
+     */
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/emerald/fda/records/api/dto/fda/ActiveIngredientDto.java
+++ b/src/main/java/com/emerald/fda/records/api/dto/fda/ActiveIngredientDto.java
@@ -1,0 +1,10 @@
+package com.emerald.fda.records.api.dto.fda;
+
+
+/**
+ * Data Transfer Object for an active ingredient in a product.
+ */
+public record ActiveIngredientDto(
+        String name,
+        String strength
+) {}

--- a/src/main/java/com/emerald/fda/records/api/dto/fda/DrugApplicationResultDto.java
+++ b/src/main/java/com/emerald/fda/records/api/dto/fda/DrugApplicationResultDto.java
@@ -1,0 +1,14 @@
+package com.emerald.fda.records.api.dto.fda;
+
+import java.util.List;
+
+/**
+ * Data Transfer Object for a drug application result from the FDA API.
+ */
+public record DrugApplicationResultDto(
+        List<SubmissionDto> submissions,
+        String application_number,
+        String sponsor_name,
+        OpenFdaDto openfda,
+        List<ProductDto> products
+) {}

--- a/src/main/java/com/emerald/fda/records/api/dto/fda/FdaResponseDto.java
+++ b/src/main/java/com/emerald/fda/records/api/dto/fda/FdaResponseDto.java
@@ -1,0 +1,11 @@
+package com.emerald.fda.records.api.dto.fda;
+
+import java.util.List;
+
+/**
+ * Data Transfer Object for the root FDA API response.
+ */
+public record FdaResponseDto(
+        MetaDto meta,
+        List<DrugApplicationResultDto> results
+) {}

--- a/src/main/java/com/emerald/fda/records/api/dto/fda/MetaDto.java
+++ b/src/main/java/com/emerald/fda/records/api/dto/fda/MetaDto.java
@@ -1,0 +1,12 @@
+package com.emerald.fda.records.api.dto.fda;
+
+/**
+ * Data Transfer Object for the metadata section of the FDA API response.
+ */
+public record MetaDto(
+        String disclaimer,
+        String terms,
+        String license,
+        String last_updated,
+        ResultsMetaDto results
+) {}

--- a/src/main/java/com/emerald/fda/records/api/dto/fda/OpenFdaDto.java
+++ b/src/main/java/com/emerald/fda/records/api/dto/fda/OpenFdaDto.java
@@ -1,0 +1,22 @@
+package com.emerald.fda.records.api.dto.fda;
+
+import java.util.List;
+
+/**
+ * Data Transfer Object for the OpenFDA section of a drug application.
+ */
+public record OpenFdaDto(
+        List<String> application_number,
+        List<String> brand_name,
+        List<String> generic_name,
+        List<String> manufacturer_name,
+        List<String> product_ndc,
+        List<String> product_type,
+        List<String> route,
+        List<String> substance_name,
+        List<String> rxcui,
+        List<String> spl_id,
+        List<String> spl_set_id,
+        List<String> package_ndc,
+        List<String> unii
+) {}

--- a/src/main/java/com/emerald/fda/records/api/dto/fda/ProductDto.java
+++ b/src/main/java/com/emerald/fda/records/api/dto/fda/ProductDto.java
@@ -1,0 +1,17 @@
+package com.emerald.fda.records.api.dto.fda;
+
+import java.util.List;
+
+/**
+ * Data Transfer Object for a product in a drug application.
+ */
+public record ProductDto(
+        String product_number,
+        String reference_drug,
+        String brand_name,
+        List<ActiveIngredientDto> active_ingredients,
+        String reference_standard,
+        String dosage_form,
+        String route,
+        String marketing_status
+) {}

--- a/src/main/java/com/emerald/fda/records/api/dto/fda/ResultsMetaDto.java
+++ b/src/main/java/com/emerald/fda/records/api/dto/fda/ResultsMetaDto.java
@@ -1,0 +1,10 @@
+package com.emerald.fda.records.api.dto.fda;
+
+/**
+ * Data Transfer Object for the results metadata section of the FDA API response.
+ */
+public record ResultsMetaDto(
+        int skip,
+        int limit,
+        int total
+) {}

--- a/src/main/java/com/emerald/fda/records/api/dto/fda/SubmissionDto.java
+++ b/src/main/java/com/emerald/fda/records/api/dto/fda/SubmissionDto.java
@@ -1,0 +1,13 @@
+package com.emerald.fda.records.api.dto.fda;
+
+/**
+ * Data Transfer Object for a submission in a drug application.
+ */
+public record SubmissionDto(
+        String submission_type,
+        String submission_number,
+        String submission_status,
+        String submission_status_date,
+        String submission_class_code,
+        String submission_class_code_description
+) {}

--- a/src/main/java/com/emerald/fda/records/api/service/FdaClientService.java
+++ b/src/main/java/com/emerald/fda/records/api/service/FdaClientService.java
@@ -1,0 +1,88 @@
+package com.emerald.fda.records.api.service;
+
+import com.emerald.fda.records.api.dto.fda.FdaResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Service for communicating with the FDA API.
+ */
+@Service
+@Slf4j
+public class FdaClientService {
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+
+    public FdaClientService(RestTemplate restTemplate,
+                            @Value("${fda.base.url}") String baseUrl) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * Searches for drug applications in the OpenFDA API.
+     *
+     * @param manufacturerName The manufacturer name to search for
+     * @param brandName The optional brand name to search for
+     * @return A {@link FdaResponseDto} object containing the search results
+     */
+    public FdaResponseDto searchDrugApplications(
+            String manufacturerName,
+            String brandName,
+            int skip,
+            int limit) {
+
+        log.info("Searching for drug applications with manufacturer: {}, brand: {}, skip: {}, limit: {}",
+                manufacturerName, brandName, skip, limit);
+
+        var builder = UriComponentsBuilder.fromUriString(baseUrl);
+
+        // Build the search query
+        var searchQuery = buildSearchQuery(manufacturerName, brandName);
+
+        // Add query parameters
+        builder.queryParam("search", searchQuery);
+        builder.queryParam("skip", skip);
+        builder.queryParam("limit", limit);
+
+        var url = builder.toUriString();
+        log.debug("FDA API request URL: {}", url);
+
+        // Make the request to the FDA API
+        FdaResponseDto response = restTemplate.getForObject(url, FdaResponseDto.class);
+
+        if (response != null && response.results() != null) {
+            log.info("Found {} drug applications", response.results().size());
+        } else {
+            log.warn("No drug applications found or response is null");
+        }
+
+        return response;
+    }
+
+    /**
+     * Build the search query string for the OpenFDA API.
+     *
+     * @param manufacturerName The manufacturer name to search for
+     * @param brandName The optional brand name to search for
+     * @return The search query string
+     */
+    private String buildSearchQuery(String manufacturerName, String brandName) {
+        StringBuilder queryBuilder = new StringBuilder();
+
+        queryBuilder.append("openfda.manufacturer_name:\"")
+                .append(manufacturerName)
+                .append("\"");
+
+        if (brandName != null && !brandName.trim().isEmpty()) {
+            queryBuilder.append("+AND+openfda.brand_name:\"")
+                    .append(brandName)
+                    .append("\"");
+        }
+
+        return queryBuilder.toString();
+    }
+}

--- a/src/test/java/com/emerald/fda/records/api/service/FdaClientServiceTest.java
+++ b/src/test/java/com/emerald/fda/records/api/service/FdaClientServiceTest.java
@@ -1,0 +1,91 @@
+package com.emerald.fda.records.api.service;
+
+import com.emerald.fda.records.api.dto.fda.DrugApplicationResultDto;
+import com.emerald.fda.records.api.dto.fda.FdaResponseDto;
+import com.emerald.fda.records.api.dto.fda.MetaDto;
+import com.emerald.fda.records.api.dto.fda.ResultsMetaDto;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class FdaClientServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private FdaClientService fdaClientService;
+
+    @Captor
+    private ArgumentCaptor<String> urlCaptor;
+
+    private final String baseUrl = "https://api.fda.gov/drug/drugsfda.json";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(fdaClientService, "baseUrl", baseUrl);
+    }
+
+    @Test
+    void searchDrugApplications_ShouldCallFdaApiWithCorrectParams() {
+        // given
+        FdaResponseDto expectedResponse = new FdaResponseDto(
+                new MetaDto(null, null, null, null, new ResultsMetaDto(0, 10, 1)),
+                List.of(new DrugApplicationResultDto(null, "ANDA076805", "TARO", null, null))
+        );
+
+        when(restTemplate.getForObject(anyString(), eq(FdaResponseDto.class)))
+                .thenReturn(expectedResponse);
+
+        // when
+        FdaResponseDto actualResponse = fdaClientService.searchDrugApplications("TARO", "LORATADINE", 0, 10);
+
+        // than
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+        verify(restTemplate).getForObject(urlCaptor.capture(), eq(FdaResponseDto.class));
+
+        String capturedUrl = urlCaptor.getValue();
+        String decodedUrl = URLDecoder.decode(capturedUrl, StandardCharsets.UTF_8);
+
+        assertThat(decodedUrl).startsWith(baseUrl);
+        assertThat(decodedUrl).contains("search=openfda.manufacturer_name:\"TARO\" AND openfda.brand_name:\"LORATADINE\"");
+        assertThat(decodedUrl).contains("skip=0");
+        assertThat(decodedUrl).contains("limit=10");
+    }
+
+    @Test
+    void searchDrugApplications_WithoutBrandName_ShouldNotIncludeBrandNameInQuery() {
+        // given
+        when(restTemplate.getForObject(anyString(), eq(FdaResponseDto.class)))
+                .thenReturn(new FdaResponseDto(null, null));
+
+        // when
+        fdaClientService.searchDrugApplications("TARO", null, 0, 10);
+
+        // then
+        verify(restTemplate).getForObject(urlCaptor.capture(), eq(FdaResponseDto.class));
+
+        String capturedUrl = urlCaptor.getValue();
+        String decodedUrl = URLDecoder.decode(capturedUrl, StandardCharsets.UTF_8);
+
+        assertThat(decodedUrl).contains("search=openfda.manufacturer_name:\"TARO\"");
+        assertThat(decodedUrl).doesNotContain("AND openfda.brand_name");
+    }
+}


### PR DESCRIPTION
This PR implements the FDA client service:

- RestTemplate configuration for HTTP communication
- FDA client service for searching drug applications
- Support for manufacturer name and optional brand name filtering
- Pagination parameters (skip & limit)
- Unit tests