### PR TITLE
Persistence Layer Implementation

### DIFF
--- a/src/main/java/com/emerald/fda/records/api/entity/DrugApplicationRecord.java
+++ b/src/main/java/com/emerald/fda/records/api/entity/DrugApplicationRecord.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
+import java.util.HashSet;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,9 +52,9 @@ public class DrugApplicationRecord {
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(
             name = "product_numbers",
-            joinColumns = @JoinColumn(name = "application_number") // Match Primary Key Name
+            joinColumns = @JoinColumn(name = "application_number")
     )
     @Column(name = "product_number", nullable = false)
     @Builder.Default
-    private Set<String> productNumber;
+    private Set<String> productNumbers = new HashSet<>();
 }

--- a/src/main/java/com/emerald/fda/records/api/entity/DrugApplicationRecord.java
+++ b/src/main/java/com/emerald/fda/records/api/entity/DrugApplicationRecord.java
@@ -19,13 +19,13 @@ import lombok.Setter;
  * Entity class representing a drug application record stored in the system.
  */
 @Entity
-@Table(name = "drug_application_records")
+@Table(name = "drug_application_record")
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class DrugApplicationRecords {
+public class DrugApplicationRecord {
     /**
      * Application number, used as the primary key.
      */

--- a/src/main/java/com/emerald/fda/records/api/entity/DrugApplicationRecords.java
+++ b/src/main/java/com/emerald/fda/records/api/entity/DrugApplicationRecords.java
@@ -1,0 +1,59 @@
+package com.emerald.fda.records.api.entity;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Entity class representing a drug application record stored in the system.
+ */
+@Entity
+@Table(name = "drug_application_records")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DrugApplicationRecords {
+    /**
+     * Application number, used as the primary key.
+     */
+    @Id
+    @Column(name = "application_number", nullable = false, unique = true)
+    private String applicationNumber;
+
+    /**
+     * Name of the manufacturer.
+     */
+    @Column(name = "manufacturer_name", nullable = false)
+    private String manufacturerName;
+
+    /**
+     * Name of the substance.
+     */
+    @Column(name = "substance_name", nullable = false)
+    private String substanceName;
+
+    /**
+     * Collection of product numbers associated with this application.
+     */
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "product_numbers",
+            joinColumns = @JoinColumn(name = "application_number") // Match Primary Key Name
+    )
+    @Column(name = "product_number", nullable = false)
+    @Builder.Default
+    private Set<String> productNumber;
+}

--- a/src/main/java/com/emerald/fda/records/api/repository/DrugApplicationRecordRepository.java
+++ b/src/main/java/com/emerald/fda/records/api/repository/DrugApplicationRecordRepository.java
@@ -1,0 +1,17 @@
+package com.emerald.fda.records.api.repository;
+
+import com.emerald.fda.records.api.entity.DrugApplicationRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository interface for managing {@link DrugApplicationRecord} entities.
+ */
+public interface DrugApplicationRecordRepository extends JpaRepository<DrugApplicationRecord, String> {
+    /**
+     * Finds all drug applications with pagination.
+     */
+    @Override
+    Page<DrugApplicationRecord> findAll(Pageable pageable);
+}

--- a/src/test/java/com/emerald/fda/records/api/repository/DrugApplicationRecordRepositoryTest.java
+++ b/src/test/java/com/emerald/fda/records/api/repository/DrugApplicationRecordRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.emerald.fda.records.api.repository;
+
+import com.emerald.fda.records.api.entity.DrugApplicationRecord;
+import java.util.Set;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class DrugApplicationRecordRepositoryTest {
+    @Autowired
+    private DrugApplicationRecordRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void saveAndFindById_ShouldSaveAndRetrieveDrugApplication() {
+        // given
+        var application = createDrugApplication("ANDA076805", "TARO", "LORATADINE", Set.of("001"));
+
+        // when
+        repository.save(application);
+        var foundApplication = repository.findById("ANDA076805");
+
+        // then
+        assertThat(foundApplication).isPresent()
+                .get()
+                .satisfies(app -> {
+                    assertThat(app.getApplicationNumber()).isEqualTo("ANDA076805");
+                    assertThat(app.getManufacturerName()).isEqualTo("TARO");
+                    assertThat(app.getSubstanceName()).isEqualTo("LORATADINE");
+                    assertThat(app.getProductNumbers()).containsExactlyInAnyOrder("001");
+                });
+    }
+
+    @Test
+    void findAll_ShouldReturnAllDrugApplications() {
+        // given
+        var application1 = createDrugApplication("ANDA076805", "TARO", "LORATADINE", Set.of("001"));
+        var application2 = createDrugApplication("ANDA076806", "OTHER", "SUBSTANCE", Set.of("002"));
+
+        repository.save(application1);
+        repository.save(application2);
+
+        // when
+        var applications = repository.findAll(PageRequest.of(0, 10));
+
+        // then
+        assertThat(applications.getTotalElements()).isEqualTo(2);
+        assertThat(applications.getContent()).extracting(DrugApplicationRecord::getApplicationNumber)
+                .containsExactlyInAnyOrder("ANDA076805", "ANDA076806");
+    }
+
+    @Test
+    void findById_ShouldReturnEmpty_WhenNotFound() {
+        // when
+        var result = repository.findById("NON_EXISTENT_ID");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void saveDuplicateId_ShouldUpdateExistingRecord() {
+        // given
+        var original = createDrugApplication("ANDA076805", "TARO", "LORATADINE", Set.of("001"));
+        repository.save(original);
+
+        var updated = createDrugApplication("ANDA076805", "NEW_MANUFACTURER", "NEW_SUBSTANCE", Set.of("002"));
+        repository.save(updated);
+
+        // when
+        var foundApplication = repository.findById("ANDA076805");
+
+        // then
+        assertThat(foundApplication).isPresent()
+                .get()
+                .satisfies(app -> {
+                    assertThat(app.getManufacturerName()).isEqualTo("NEW_MANUFACTURER");
+                    assertThat(app.getSubstanceName()).isEqualTo("NEW_SUBSTANCE");
+                    assertThat(app.getProductNumbers()).containsExactlyInAnyOrder("002");
+                });
+    }
+
+    private DrugApplicationRecord createDrugApplication(String applicationNumber, String manufacturer, String substance, Set<String> productNumbers) {
+        return DrugApplicationRecord.builder()
+                .applicationNumber(applicationNumber)
+                .manufacturerName(manufacturer)
+                .substanceName(substance)
+                .productNumbers(productNumbers)
+                .build();
+    }
+}


### PR DESCRIPTION
This PR implements the persistence layer for storing drug applications:

- DrugApplication entity with required fields
- JPA repository for CRUD operations
- Integration tests for the repository

The entity is designed to store exactly the required fields:
- Application number (as ID)
- Manufacturer name
- Substance name
- All product numbers (as a collection)