### PR TITLE
Service Layer Implementation

### DIFF
--- a/src/main/java/com/emerald/fda/records/api/service/DrugApplicationRecordsService.java
+++ b/src/main/java/com/emerald/fda/records/api/service/DrugApplicationRecordsService.java
@@ -1,0 +1,110 @@
+package com.emerald.fda.records.api.service;
+
+import com.emerald.fda.records.api.dto.fda.FdaResponseDto;
+import com.emerald.fda.records.api.entity.DrugApplicationRecord;
+import com.emerald.fda.records.api.repository.DrugApplicationRecordRepository;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service for managing drug applications.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DrugApplicationRecordsService {
+    private final DrugApplicationRecordRepository repository;
+    private final FdaClientService fdaClientService;
+
+    /**
+     * Searches for drug applications in the FDA database.
+     *
+     * @param manufacturerName The manufacturer name to search for
+     * @param brandName        The optional brand name to search for
+     * @param skip             The number of results to skip
+     * @param limit            The maximum number of results to return
+     * @return A {@link FdaResponseDto} object containing the search results
+     */
+    public FdaResponseDto searchDrugApplicationRecords(
+            String manufacturerName,
+            String brandName,
+            int skip,
+            int limit) {
+
+        return fdaClientService.searchDrugApplicationRecords(manufacturerName, brandName, skip, limit);
+    }
+
+    /**
+     * Saves a drug application to the database.
+     *
+     * @param applicationNumber The application number of the drug application
+     * @param manufacturerName  The manufacturer name of the drug application
+     * @param substanceName     The substance name of the drug application
+     * @param productNumbers    The product numbers of the drug application
+     * @return The saved drug application
+     */
+    @Transactional
+    public DrugApplicationRecord saveDrugApplicationRecord(
+            String applicationNumber,
+            String manufacturerName,
+            String substanceName,
+            Set<String> productNumbers) {
+
+        log.info("Saving drug application with number: {}", applicationNumber);
+
+        var existingApplication = repository.findById(applicationNumber);
+
+        if (existingApplication.isPresent()) {
+            log.info("Updating existing drug application: {}", applicationNumber);
+
+            var application = existingApplication.get();
+            application.setManufacturerName(manufacturerName);
+            application.setSubstanceName(substanceName);
+            application.getProductNumbers().addAll(productNumbers);
+
+            return repository.save(application);
+        } else {
+            log.info("Creating new drug application: {}", applicationNumber);
+
+            var newApplication = DrugApplicationRecord.builder()
+                    .applicationNumber(applicationNumber)
+                    .manufacturerName(manufacturerName)
+                    .substanceName(substanceName)
+                    .productNumbers(productNumbers)
+                    .build();
+
+            return repository.save(newApplication);
+        }
+    }
+
+    /**
+     * Gets all drug applications with pagination.
+     *
+     * @param pageable The pagination information
+     * @return A {@link Page} object containing the drug applications
+     */
+    public Page<DrugApplicationRecord> getAllDrugApplicationRecords(Pageable pageable) {
+        log.info("Getting all drug applications with page: {}, size: {}",
+                pageable.getPageNumber(), pageable.getPageSize());
+
+        return repository.findAll(pageable);
+    }
+
+    /**
+     * Gets a drug application by its application number.
+     *
+     * @param applicationNumber The application number of the drug application
+     * @return An {@link Optional} object containing the drug application
+     */
+    public Optional<DrugApplicationRecord> getDrugApplicationById(String applicationNumber) {
+        log.info("Getting drug application by ID: {}", applicationNumber);
+
+        return repository.findById(applicationNumber);
+    }
+}

--- a/src/main/java/com/emerald/fda/records/api/service/FdaClientService.java
+++ b/src/main/java/com/emerald/fda/records/api/service/FdaClientService.java
@@ -29,7 +29,7 @@ public class FdaClientService {
      * @param brandName The optional brand name to search for
      * @return A {@link FdaResponseDto} object containing the search results
      */
-    public FdaResponseDto searchDrugApplications(
+    public FdaResponseDto searchDrugApplicationRecords(
             String manufacturerName,
             String brandName,
             int skip,

--- a/src/test/java/com/emerald/fda/records/api/service/DrugApplicationRecordsServiceTest.java
+++ b/src/test/java/com/emerald/fda/records/api/service/DrugApplicationRecordsServiceTest.java
@@ -1,0 +1,214 @@
+package com.emerald.fda.records.api.service;
+
+import com.emerald.fda.records.api.dto.fda.DrugApplicationResultDto;
+import com.emerald.fda.records.api.dto.fda.FdaResponseDto;
+import com.emerald.fda.records.api.dto.fda.MetaDto;
+import com.emerald.fda.records.api.dto.fda.OpenFdaDto;
+import com.emerald.fda.records.api.dto.fda.ProductDto;
+import com.emerald.fda.records.api.dto.fda.ResultsMetaDto;
+import com.emerald.fda.records.api.entity.DrugApplicationRecord;
+import com.emerald.fda.records.api.repository.DrugApplicationRecordRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class DrugApplicationRecordsServiceTest {
+    @Mock
+    private DrugApplicationRecordRepository repository;
+
+    @Mock
+    private FdaClientService fdaClientService;
+
+    @InjectMocks
+    private DrugApplicationRecordsService service;
+
+    @Test
+    void searchDrugApplications_ShouldDelegateToDdaClientService() {
+        // Arrange
+        var expectedResponse = new FdaResponseDto(
+                new MetaDto(null, null, null, null, new ResultsMetaDto(0, 10, 1)),
+                List.of(new DrugApplicationResultDto(null, "ANDA076805", "TARO", null, null))
+        );
+
+        when(fdaClientService.searchDrugApplicationRecords("TARO", "LORATADINE", 0, 10))
+                .thenReturn(expectedResponse);
+
+        // Act
+        FdaResponseDto actualResponse = service.searchDrugApplicationRecords("TARO", "LORATADINE", 0, 10);
+
+        // Assert
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+        verify(fdaClientService).searchDrugApplicationRecords("TARO", "LORATADINE", 0, 10);
+    }
+
+    @Test
+    void saveDrugApplication_WithNewApplication_ShouldCreateNewEntity() {
+        // Arrange
+        String applicationNumber = "ANDA076805";
+        String manufacturerName = "TARO";
+        String substanceName = "LORATADINE";
+        var productNumbers = Set.of("001", "002");
+
+        when(repository.findById(applicationNumber)).thenReturn(Optional.empty());
+        when(repository.save(any(DrugApplicationRecord.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        var result = service.saveDrugApplicationRecord(
+                applicationNumber, manufacturerName, substanceName, productNumbers);
+
+        // Assert
+        assertThat(result.getApplicationNumber()).isEqualTo(applicationNumber);
+        assertThat(result.getManufacturerName()).isEqualTo(manufacturerName);
+        assertThat(result.getSubstanceName()).isEqualTo(substanceName);
+        assertThat(result.getProductNumbers()).isEqualTo(productNumbers);
+
+        verify(repository).findById(applicationNumber);
+        verify(repository).save(any(DrugApplicationRecord.class));
+    }
+
+    @Test
+    void saveDrugApplication_WithExistingApplication_ShouldUpdateEntity() {
+        // Arrange
+        String applicationNumber = "ANDA076805";
+        String manufacturerName = "UPDATED MANUFACTURER";
+        String substanceName = "UPDATED SUBSTANCE";
+        Set<String> productNumbers = Set.of("002", "003");
+
+        var existingApplication = DrugApplicationRecord.builder()
+                .applicationNumber(applicationNumber)
+                .manufacturerName("TARO")
+                .substanceName("LORATADINE")
+                .productNumbers(new HashSet<>(Set.of("001")))
+                .build();
+
+        when(repository.findById(applicationNumber)).thenReturn(Optional.of(existingApplication));
+        when(repository.save(any(DrugApplicationRecord.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        var result = service.saveDrugApplicationRecord(
+                applicationNumber, manufacturerName, substanceName, productNumbers);
+
+        // Assert
+        assertThat(result.getApplicationNumber()).isEqualTo(applicationNumber);
+        assertThat(result.getManufacturerName()).isEqualTo(manufacturerName);
+        assertThat(result.getSubstanceName()).isEqualTo(substanceName);
+        assertThat(result.getProductNumbers()).containsExactlyInAnyOrder("001", "002", "003");
+
+        verify(repository).findById(applicationNumber);
+        verify(repository).save(existingApplication);
+    }
+
+    @Test
+    void saveDrugApplicationFromFdaResult_ShouldExtractFieldsAndSave() {
+        // Arrange
+        var openFdaDto = new OpenFdaDto(
+                List.of("ANDA076805"),
+                List.of("BRAND"),
+                List.of("GENERIC"),
+                List.of("TARO"),
+                null, null, null,
+                List.of("LORATADINE"),
+                null, null, null, null, null
+        );
+
+        var product1 = new ProductDto("001", null, null, null, null, null, null, null);
+        var product2 = new ProductDto("002", null, null, null, null, null, null, null);
+
+        when(repository.findById(anyString())).thenReturn(Optional.empty());
+        when(repository.save(any(DrugApplicationRecord.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        var result = service.saveDrugApplicationRecord("ANDA076805", "TARO", "LORATADINE", Set.of("001", "002"));
+
+        // Assert
+        assertThat(result.getApplicationNumber()).isEqualTo("ANDA076805");
+        assertThat(result.getManufacturerName()).isEqualTo("TARO");
+        assertThat(result.getSubstanceName()).isEqualTo("LORATADINE");
+        assertThat(result.getProductNumbers()).containsExactlyInAnyOrder("001", "002");
+
+        verify(repository).save(any(DrugApplicationRecord.class));
+    }
+
+    @Test
+    void getAllDrugApplications_ShouldReturnPageFromRepository() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        List<DrugApplicationRecord> applications = List.of(
+                DrugApplicationRecord.builder()
+                        .applicationNumber("ANDA076805")
+                        .manufacturerName("TARO")
+                        .substanceName("LORATADINE")
+                        .productNumbers(Set.of("001"))
+                        .build(),
+                DrugApplicationRecord.builder()
+                        .applicationNumber("ANDA076806")
+                        .manufacturerName("OTHER")
+                        .substanceName("SUBSTANCE")
+                        .productNumbers(Set.of("002"))
+                        .build()
+        );
+
+        Page<DrugApplicationRecord> expectedPage = new PageImpl<>(applications, pageable, applications.size());
+        when(repository.findAll(pageable)).thenReturn(expectedPage);
+
+        // Act
+        Page<DrugApplicationRecord> actualPage = service.getAllDrugApplicationRecords(pageable);
+
+        // Assert
+        assertThat(actualPage).isEqualTo(expectedPage);
+        assertThat(actualPage.getContent()).hasSize(2);
+        verify(repository).findAll(pageable);
+    }
+
+    @Test
+    void getDrugApplicationById_ShouldReturnApplicationFromRepository() {
+        // Arrange
+        String applicationNumber = "ANDA076805";
+        var expectedApplication = DrugApplicationRecord.builder()
+                .applicationNumber(applicationNumber)
+                .manufacturerName("TARO")
+                .substanceName("LORATADINE")
+                .productNumbers(Set.of("001"))
+                .build();
+
+        when(repository.findById(applicationNumber)).thenReturn(Optional.of(expectedApplication));
+
+        // Act
+        Optional<DrugApplicationRecord> actualApplication = service.getDrugApplicationById(applicationNumber);
+
+        // Assert
+        assertThat(actualApplication).isPresent();
+        assertThat(actualApplication.get()).isEqualTo(expectedApplication);
+        verify(repository).findById(applicationNumber);
+    }
+
+    @Test
+    void getDrugApplicationById_WithNonExistentId_ShouldReturnEmpty() {
+        // Arrange
+        String applicationNumber = "NONEXISTENT";
+        when(repository.findById(applicationNumber)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<DrugApplicationRecord> actualApplication = service.getDrugApplicationById(applicationNumber);
+
+        // Assert
+        assertThat(actualApplication).isEmpty();
+        verify(repository).findById(applicationNumber);
+    }
+}

--- a/src/test/java/com/emerald/fda/records/api/service/FdaClientServiceTest.java
+++ b/src/test/java/com/emerald/fda/records/api/service/FdaClientServiceTest.java
@@ -44,7 +44,7 @@ class FdaClientServiceTest {
     }
 
     @Test
-    void searchDrugApplications_ShouldCallFdaApiWithCorrectParams() {
+    void searchDrugApplicationRecords_ShouldCallFdaApiWithCorrectParams() {
         // given
         FdaResponseDto expectedResponse = new FdaResponseDto(
                 new MetaDto(null, null, null, null, new ResultsMetaDto(0, 10, 1)),
@@ -55,7 +55,7 @@ class FdaClientServiceTest {
                 .thenReturn(expectedResponse);
 
         // when
-        FdaResponseDto actualResponse = fdaClientService.searchDrugApplications("TARO", "LORATADINE", 0, 10);
+        FdaResponseDto actualResponse = fdaClientService.searchDrugApplicationRecords("TARO", "LORATADINE", 0, 10);
 
         // than
         assertThat(actualResponse).isEqualTo(expectedResponse);
@@ -71,13 +71,13 @@ class FdaClientServiceTest {
     }
 
     @Test
-    void searchDrugApplications_WithoutBrandName_ShouldNotIncludeBrandNameInQuery() {
+    void searchDrugApplicationRecords_WithoutBrandName_ShouldNotIncludeBrandNameInQuery() {
         // given
         when(restTemplate.getForObject(anyString(), eq(FdaResponseDto.class)))
                 .thenReturn(new FdaResponseDto(null, null));
 
         // when
-        fdaClientService.searchDrugApplications("TARO", null, 0, 10);
+        fdaClientService.searchDrugApplicationRecords("TARO", null, 0, 10);
 
         // then
         verify(restTemplate).getForObject(urlCaptor.capture(), eq(FdaResponseDto.class));


### PR DESCRIPTION
This PR implements the service layer for the FDA Records API:

- Drug application records service with business logic
- Methods for saving and retrieving drug applications
- Pagination support for retrieving applications
- Unit tests